### PR TITLE
 Add non coupling input reshape in HEALPixUNet forward

### DIFF
--- a/training/dlwp/model/models/unet.py
+++ b/training/dlwp/model/models/unet.py
@@ -165,6 +165,21 @@ class HEALPixUNet(th.nn.Module):
         :param coupings: sequence of dictionaries that describe coupling mechanisms
         """
         super().__init__()
+
+        if n_constants == 0 and decoder_input_channels == 0:
+            raise NotImplementedError(
+                "support for models with no constant fields and no decoder inputs (TOA insolation) is not available at this time."
+            )
+        if len(couplings) > 0:
+            if n_constants == 0:
+                raise NotImplementedError(
+                    "support for coupled models with no constant fields is not available at this time."
+                )
+            if decoder_input_channels == 0:
+                raise NotImplementedError(
+                    "support for coupled models with no decoder inputs (TOA insolation) is not available at this time."
+                )
+        
         # add coupled fields to input channels for model initialization 
         self.coupled_channels = self._compute_coupled_channels(couplings) 
         self.couplings = couplings 
@@ -308,7 +323,14 @@ is not available at this time.')
                 else:
                     input_tensor = self._reshape_inputs(inputs, step)
             else:
-                input_tensor = self._reshape_inputs([outputs[-1]] + list(inputs[1:3]) + [inputs[3][step]], step)
+                if len(self.couplings) > 0:
+                    input_tensor = self._reshape_inputs(
+                        [outputs[-1]] + list(inputs[1:3]) + [inputs[3][step]], step
+                    )
+                else:
+                    input_tensor = self._reshape_inputs(
+                        [outputs[-1]] + list(inputs[1:]), step
+                    )
 
             encodings = self.encoder(input_tensor)
             decodings = self.decoder(encodings)


### PR DESCRIPTION
When I add ci-test function to HEALPixUNet, I update the initialization with the condition same as HEALPixRecUNet and update forward with non-coupling input.